### PR TITLE
Changing "module.exports" by "export default"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ interface Options {
   external?: Array<string>;
 }
 
-module.exports = (options?: Partial<Options>): Plugin => {
+const removeConsole = (options?: Partial<Options>): Plugin => {
   const { external } = options || {};
   return {
     name: "vite:remove-console",
@@ -28,3 +28,5 @@ module.exports = (options?: Partial<Options>): Plugin => {
     }
   };
 };
+
+export default removeConsole;


### PR DESCRIPTION
The `export default` solve this issue:
Could not find a declaration file for module 'vite-plugin-remove-console'. './node_modules/vite-plugin-remove-console/dist/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/vite-plugin-remove-console` if it exists or add a new declaration (.d.ts) file containing `declare module 'vite-plugin-remove-console';`ts(7016)